### PR TITLE
sdm845-common: Don't built custom LiveDisplay HAL for all targets

### DIFF
--- a/sdm845.mk
+++ b/sdm845.mk
@@ -80,8 +80,7 @@ PRODUCT_PACKAGES += \
 
 # LiveDisplay
 PRODUCT_PACKAGES += \
-    lineage.livedisplay@2.0-service-sdm \
-    lineage.livedisplay@2.0-service.xiaomi_sdm845
+    lineage.livedisplay@2.0-service-sdm
 
 # Media
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
 * Due to some recent AOSP change, the service is now constantly
   restarting on the targets where the interface is not supported.
   Supported targets should build it if desired.

Change-Id: Ic612c3cf37d2b3b7316b064d319e954c2cb812bf