### PR TITLE
sdm845-common: Add IIFAAService for Alipay fingerprint payment

### DIFF
--- a/org.ifaa.android.manager/Android.mk
+++ b/org.ifaa.android.manager/Android.mk
@@ -9,7 +9,11 @@ LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 
 LOCAL_SRC_FILES := \
-    $(call all-java-files-under, src)
+    $(call all-java-files-under, src) \
+    $(call all-Iaidl-files-under, src)
+
+LOCAL_AIDL_INCLUDES := \
+    $(call all-Iaidl-files-under, src)
 
 LOCAL_MODULE := org.ifaa.android.manager
 LOCAL_MODULE_TAGS := optional

--- a/org.ifaa.android.manager/src/org/ifaa/android/manager/IIFAAService.aidl
+++ b/org.ifaa.android.manager/src/org/ifaa/android/manager/IIFAAService.aidl
@@ -1,0 +1,12 @@
+package org.ifaa.android.manager;
+
+interface IIFAAService {
+    byte[] processCmd_v2(in byte[] param);
+    int[] getIDList(int bioType);
+    int faceEnroll(String sessionId, int flags);
+    int faceUpgrade(int action, String path, int offset, in byte[] data, int data_len);
+    int faceAuthenticate_v2(String sessionId, int flags);
+    int faceCancel_v2(String sessionId);
+    byte[] faceInvokeCommand(in byte[] param);
+    int faceGetCellinfo();
+}


### PR DESCRIPTION
  * The org.ifaa.android.manager.IIFAAService has been moved
    from the SoterService.apk to MIUI framework, at least
    since MIUI 9.4.26. Adding this interface will fix the
    SoterService crashing when launching Alipay.

Change-Id: Ic97467eb0a8fe92b49e0edbedd56f1866c5fa01e