### PR TITLE
sdm845-common: Start loc_launcher as gps user

### DIFF
--- a/config.fs
+++ b/config.fs
@@ -67,6 +67,12 @@ user:  AID_GPS
 group: AID_GPS
 caps: NET_BIND_SERVICE
 
+[vendor/bin/loc_launcher]
+mode: 0755
+user:  AID_GPS
+group: AID_GPS
+caps: SETUID SETGID
+
 [vendor/bin/xtwifi-client]
 mode: 0755
 user:  AID_GPS


### PR DESCRIPTION
Start loc_launcher as gps user and set uid/gid of loc_launcher
to gps and enable SETUID and SETGID caps for loc_launcher, so
that we can start loc_launcher as gps user instead of root and
still have capabilities for SETUID and SETGID. Also remove not
required permissions groups for loc_launcher.

Change-Id: Ie9f1506874b3c3148f9170c8d5db9afd1e70025c
CRs-Fixed: 2192881