### PR TITLE
sdm845-common: Decommonize ACDB loader libraries

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -24,7 +24,6 @@ vendor/lib/rfsa/adsp/libsns_low_lat_stream_skel.so
 # Audio
 vendor/lib64/hw/audio.primary.sdm845.so
 vendor/lib64/libacdb-fts.so
-vendor/lib64/libacdbloader.so
 vendor/lib64/libacdbrtac.so
 vendor/lib64/libadiertac.so
 vendor/lib64/libaudcal.so
@@ -37,7 +36,6 @@ vendor/lib64/libqtigef.so
 vendor/lib64/libtinycompress_vendor.so
 vendor/lib/hw/audio.primary.sdm845.so
 vendor/lib/libacdb-fts.so
-vendor/lib/libacdbloader.so
 vendor/lib/libacdbrtac.so
 vendor/lib/libadiertac.so
 vendor/lib/libadm.so


### PR DESCRIPTION
 * Turns out that equuleus and ursa have different ACDB files to load

Change-Id: Ibb521bc7138f6b9757f8947761e2c3f9afa3dc95